### PR TITLE
Allow mime types with numbers (such as mp4, mp3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var mkdirp = require('mkdirp');
 
 exports.isMatchToBase64 = function isMatchToBase64(dataString) {
-    return dataString.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+    return dataString.match(/^data:([A-Za-z0-9-+\/]+);base64,(.+)$/);
 };
 
 function decodeBase64Image(dataString) {


### PR DESCRIPTION
The existing regex only allows mime types which are comprised of letters, so mp3, mp4 and similar are not matched. 

This updates the regex to allow numbers in the mime type. 